### PR TITLE
Fixed cabal file so all required symbols will appear in the .so on OSX.

### DIFF
--- a/limp-cbc.cabal
+++ b/limp-cbc.cabal
@@ -317,6 +317,7 @@ library
       cbits/coin/CbcCutGenerator.cpp
       cbits/coin/CbcCutModifier.cpp
       cbits/coin/CbcDummyBranchingObject.cpp
+      cbits/coin/CbcOrClpParam.cpp
       cbits/coin/CbcEventHandler.cpp
       cbits/coin/CbcFathom.cpp
       cbits/coin/CbcFixVariable.cpp


### PR DESCRIPTION
This fixes issue with missing symbols in the dynamic library on OSX 10.9.

Currently, limp-cbc installs fine, however when trying to run a simple test I get the following error:
<pre>
can't load .so/.DLL for: /Users/marcinf/Library/Haskell/ghc-7.10.1/lib/limp-cbc-0.3.2.0/lib/libHSlimpc_L25hIzRiL4f0AvEMZizRFl-ghc7.10.1.dylib (dlopen(/Users/marcinf/Library/Haskell/ghc-7.10.1/lib/limp-cbc-0.3.2.0/lib/libHSlimpc_L25hIzRiL4f0AvEMZizRFl-ghc7.10.1.dylib, 5): Symbol not found: _CbcOrClpEnvironmentIndex
  Referenced from: /Users/marcinf/Library/Haskell/ghc-7.10.1/lib/limp-cbc-0.3.2.0/lib/libHSlimpc_L25hIzRiL4f0AvEMZizRFl-ghc7.10.1.dylib
  Expected in: flat namespace
 in /Users/marcinf/Library/Haskell/ghc-7.10.1/lib/limp-cbc-0.3.2.0/lib/libHSlimpc_L25hIzRiL4f0AvEMZizRFl-ghc7.10.1.dylib)
</pre>

It seems that missing symbols are in C++ file I've added to list. Since I don't know much about interfacing between Haskell and C++ it would be nice to review if it doesn't create some unexpected problem somewhere else. This was tested only on OSX 10.9 with GHC 7.10.1 (I don't have other machines to test on), so it would also make sense to test on some other configuration.